### PR TITLE
Add presigned_put_object and presigned_get_object methods on MockMinioClient

### DIFF
--- a/pytest_minio_mock/plugin.py
+++ b/pytest_minio_mock/plugin.py
@@ -256,6 +256,28 @@ class MockMinioClient:
         extra_query_params=None,
     ):
         return "{}/{}/{}".format(self._base_url, bucket_name, object_name)
+    
+    def presigned_put_object(self, bucket_name, object_name,
+                             expires=datetime.timedelta(days=7)):
+        return self.get_presigned_url("PUT", bucket_name, object_name, expires)
+
+    def presigned_get_object(self, bucket_name, object_name,
+                             expires=datetime.timedelta(days=7),
+                             response_headers=None,
+                             request_date=None,
+                             version_id=None,
+                             extra_query_params=None):
+        
+        return self.get_presigned_url(
+            "GET",
+            bucket_name,
+            object_name,
+            expires,
+            response_headers=response_headers,
+            request_date=request_date,
+            version_id=version_id,
+            extra_query_params=extra_query_params,
+        )
 
     def list_buckets(self):
         try:

--- a/tests/test_minio_mock.py
+++ b/tests/test_minio_mock.py
@@ -77,6 +77,32 @@ def test_get_presigned_url(minio_mock):
     url = client.get_presigned_url("GET", bucket_name, object_name)
     assert validators.url(url)
 
+@pytest.mark.UNIT
+@pytest.mark.API
+def test_presigned_put_url(minio_mock):
+    bucket_name = "test-bucket"
+    object_name = "test-object"
+    file_path = "tests/fixtures/maya.jpeg"
+
+    client = Minio("http://local.host:9000")
+    client.make_bucket(bucket_name)
+    client.fput_object(bucket_name, object_name, file_path)
+    url = client.presigned_put_object(bucket_name, object_name)
+    assert validators.url(url)
+
+@pytest.mark.UNIT
+@pytest.mark.API
+def test_presigned_get_url(minio_mock):
+    bucket_name = "test-bucket"
+    object_name = "test-object"
+    file_path = "tests/fixtures/maya.jpeg"
+
+    client = Minio("http://local.host:9000")
+    client.make_bucket(bucket_name)
+    client.fput_object(bucket_name, object_name, file_path)
+    url = client.presigned_get_object(bucket_name, object_name)
+    assert validators.url(url)
+
 
 @pytest.mark.UNIT
 @pytest.mark.API


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/oussjarrousse/pytest-minio-mock for help on Contributing -->

## Change Summary

- Add `presigned_put_object` method mocked on MockMinioClient
- Add `presigned_get_object` method mocked on MockMinioClient

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass remains.
* [x] My PR is ready to review
