### PR TITLE
Set default for list_objects prefix and start_after arguments to Noe

### DIFF
--- a/pytest_minio_mock/plugin.py
+++ b/pytest_minio_mock/plugin.py
@@ -21,6 +21,7 @@ by simulating the Minio environment. It's useful in scenarios where you want to 
 application interacts correctly with Minio, without the overhead of connecting to an actual Minio
 server.
 """
+
 import copy
 import datetime
 import io
@@ -495,9 +496,9 @@ class MockMinioBucket:
 
     def list_objects(
         self,
-        prefix="",
+        prefix=None,
         recursive=False,
-        start_after="",
+        start_after=None,
         include_version=False,
     ):
         """
@@ -507,10 +508,12 @@ class MockMinioBucket:
         # Initialization
         # bucket_objects = []
         seen_prefixes = set()
+        if prefix is None:
+            prefix = ""
 
         for object_name, obj in self.objects.items():
             if object_name.startswith(prefix) and (
-                start_after == "" or object_name > start_after
+                not start_after or object_name > start_after
             ):
                 # Handle non-recursive listing by identifying and adding unique directory names
                 if not recursive:
@@ -1164,9 +1167,9 @@ class MockMinioClient:
     def list_objects(
         self,
         bucket_name,
-        prefix="",
+        prefix=None,
         recursive=False,
-        start_after="",
+        start_after=None,
         include_version=False,
     ):
         """


### PR DESCRIPTION
This simple PR fixes #22

Note that I changed the default arguments as well because I assume the goal is to be as close to the regular python minio client as possible. 

Please let me know if you have any requests or community standards for contributing that I should adhere to!