### PR TITLE
33 fixing get object no such key

### DIFF
--- a/pytest_minio_mock/plugin.py
+++ b/pytest_minio_mock/plugin.py
@@ -503,7 +503,7 @@ class MockMinioBucket:
                 request_id=None,
                 host_id=None,
                 response="mocked_response",
-                code=404,
+                code="NoSuchKey",
                 bucket_name=self.bucket_name,
                 object_name=object_name,
             ) from exc

--- a/tests/test_minio_mock.py
+++ b/tests/test_minio_mock.py
@@ -83,7 +83,7 @@ def test_remove_bucket(minio_mock):
 
 @pytest.mark.API
 @pytest.mark.FUNC
-def test_putting_and_removing_objects_no_versionning(minio_mock):
+def test_putting_and_removing_objects_no_versioning(minio_mock):
     # simple thing
     bucket_name = "test-bucket"
     object_name = "test-object"
@@ -110,7 +110,8 @@ def test_putting_and_removing_objects_no_versionning(minio_mock):
     # test retrieving object after it has been removed
     with pytest.raises(S3Error) as error:
         _ = client.get_object(bucket_name, object_name)
-    assert "The specified key does not exist" in str(error.value)
+    assert error.value.message == "The specified key does not exist."
+    assert error.value.code == "NoSuchKey"
 
 
 @pytest.mark.API


### PR DESCRIPTION
## Change Summary
 - In `MockMinioBucket.get_object()`, when object cannot be found, raises `S3Error` with error code `NoSuchKey` instead of `404`.

## Related issue number
 - Closes #33 

## Checklist
- [x] code is ready
- [x] add tests
- [x] all tests passing
- [x] test coverage did not drop
- [x] PR is ready for review

## Additional Context

Might be a good idea to reference this part of code? 

https://github.com/minio/minio-py/blob/fd3571aa9b9402f050192ad4c6c087d2806ca9eb/minio/api.py#L378

It contains error code mapping to a more dev-friendly string. There are many other places where 3-digits error code can be replaced by string, but it depends on your decision. Cheers :)