### PR TITLE
Add missing cert_check argument to MockMinioClient

### DIFF
--- a/pytest_minio_mock/plugin.py
+++ b/pytest_minio_mock/plugin.py
@@ -763,6 +763,7 @@ class MockMinioClient:
         _region (str): The region of the server (not used in mock).
         _http_client: The HTTP client to use (not used in mock).
         _credentials: The credentials object (not used in mock).
+        _cert_check (bool): Whether to check certificates (not used in mock).
         buckets (dict): A dictionary to hold mock bucket data.
     """
 
@@ -776,6 +777,7 @@ class MockMinioClient:
         region=None,
         http_client=None,
         credentials=None,
+        cert_check=True,
     ):
         """
         Initialize the MockMinioClient with configuration similar to the real client.
@@ -789,6 +791,7 @@ class MockMinioClient:
             region (str, optional): The region of the server.
             http_client (optional): The HTTP client to use. Defaults to None.
             credentials (optional): The credentials object. Defaults to None.
+            cert_check (optional): Whether to check certificates. Defaults to True.
         """
         self._base_url = endpoint
         self._access_key = access_key
@@ -798,6 +801,7 @@ class MockMinioClient:
         self._region = region
         self._http_client = http_client
         self._credentials = credentials
+        self._cert_check = cert_check
         self.buckets = {}
 
     def connect(self, servers):


### PR DESCRIPTION
Change Summary: Minio client accepts cert_check argument to the initializer, this MR adds it to the mock

Related issue number: N/A

Checklist:
- [x] code is ready
- [ ] add tests
- [ ] all tests passing
- [ ] test coverage did not drop
- [ ] PR is ready for review

See the cert_check argument in the "Parameters" table in https://min.io/docs/minio/linux/developers/python/API.html