### PR TITLE
Version 0.4.16

### DIFF
--- a/pytest_minio_mock/__init__.py
+++ b/pytest_minio_mock/__init__.py
@@ -17,10 +17,16 @@ For more information and usage examples, please refer to the project's README.md
 
 __title__ = "pytest-minio-mock"
 __description__ = "A pytest plugin for mocking Minio S3 interactions"
-__version__ = "0.4.15"
+__version__ = "0.4.16"
 __status__ = "Production"
 __license__ = "MIT"
 __author__ = "Oussama Jarrousse"
 __maintainer__ = "Oussama Jarrousse"
 __email__ = "oussama@jarrousse.org"
-__credits__ = ["Gustavo Satheler", "@cottephi", "Wouter van Atteveldt", "@KelvinHong"]
+__credits__ = [
+    "Gustavo Satheler",
+    "@cottephi",
+    "Wouter van Atteveldt",
+    "@KelvinHong",
+    "Tomas Kazmar",
+]

--- a/pytest_minio_mock/plugin.py
+++ b/pytest_minio_mock/plugin.py
@@ -763,6 +763,7 @@ class MockMinioClient:
         _region (str): The region of the server (not used in mock).
         _http_client: The HTTP client to use (not used in mock).
         _credentials: The credentials object (not used in mock).
+        _cert_check (bool): Whether to check certificates (not used in mock).
         buckets (dict): A dictionary to hold mock bucket data.
     """
 
@@ -776,6 +777,7 @@ class MockMinioClient:
         region=None,
         http_client=None,
         credentials=None,
+        cert_check=True,
     ):
         """
         Initialize the MockMinioClient with configuration similar to the real client.
@@ -789,6 +791,7 @@ class MockMinioClient:
             region (str, optional): The region of the server.
             http_client (optional): The HTTP client to use. Defaults to None.
             credentials (optional): The credentials object. Defaults to None.
+            cert_check (optional): Whether to check certificates. Defaults to True.
         """
         self._base_url = endpoint
         self._access_key = access_key
@@ -798,6 +801,7 @@ class MockMinioClient:
         self._region = region
         self._http_client = http_client
         self._credentials = credentials
+        self._cert_check = cert_check
         self.buckets = {}
 
     def connect(self, servers):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     long_description=open("README.md", encoding="utf-8").read(),
     keywords="pytest minio mock",
     extras_require={"dev": ["pre-commit", "tox"]},
-    version="0.4.15",
+    version="0.4.16",
     long_description_content_type="text/markdown",
     classifiers=[
         "Framework :: Pytest",

--- a/tests/test_minio_mock.py
+++ b/tests/test_minio_mock.py
@@ -1,3 +1,5 @@
+"""
+"""
 import os
 import sys
 
@@ -8,53 +10,8 @@ from minio.commonconfig import ENABLED
 from minio.datatypes import Bucket
 from minio.datatypes import Object
 from minio.error import S3Error
-from minio.versioningconfig import OFF
 from minio.versioningconfig import SUSPENDED
 from minio.versioningconfig import VersioningConfig
-
-from pytest_minio_mock.plugin import MockMinioBucket
-from pytest_minio_mock.plugin import MockMinioObject
-
-
-@pytest.mark.UNIT
-class TestsMockMinioObject:
-    @pytest.mark.UNIT
-    def test_mock_minio_object_init(self):
-        mock_minio_object = MockMinioObject("test-bucket", "test-object")
-        assert mock_minio_object.versions == {}
-
-
-@pytest.mark.UNIT
-class TestsMockMinioBucket:
-    @pytest.mark.UNIT
-    def test_mock_minio_bucket_init(self):
-        mock_minio_bucket = MockMinioBucket(
-            bucket_name="test-bucket", versioning=VersioningConfig()
-        )
-        assert mock_minio_bucket.bucket_name == "test-bucket"
-        assert mock_minio_bucket.versioning.status == OFF
-        assert mock_minio_bucket.objects == {}
-
-        versioning_config = VersioningConfig(ENABLED)
-        mock_minio_bucket = MockMinioBucket(
-            bucket_name="test-bucket", versioning=versioning_config
-        )
-        assert isinstance(mock_minio_bucket._versioning, VersioningConfig)
-        assert mock_minio_bucket.versioning.status == ENABLED
-
-    @pytest.mark.UNIT
-    def test_versioning(self):
-        mock_minio_bucket = MockMinioBucket(
-            bucket_name="test-bucket", versioning=VersioningConfig()
-        )
-        versioning_config = mock_minio_bucket.versioning
-        assert isinstance(versioning_config, VersioningConfig)
-        assert versioning_config.status == OFF
-        versioning_config = VersioningConfig(status=ENABLED)
-        mock_minio_bucket.versioning = versioning_config
-        versioning_config = mock_minio_bucket.versioning
-        assert isinstance(versioning_config, VersioningConfig)
-        assert versioning_config.status == ENABLED
 
 
 @pytest.mark.UNIT

--- a/tests/test_minio_mock_bucket.py
+++ b/tests/test_minio_mock_bucket.py
@@ -1,0 +1,41 @@
+"""
+"""
+import pytest
+from minio.commonconfig import ENABLED
+from minio.versioningconfig import OFF
+from minio.versioningconfig import VersioningConfig
+
+from pytest_minio_mock.plugin import MockMinioBucket
+
+
+@pytest.mark.UNIT
+class TestsMockMinioBucket:
+    @pytest.mark.UNIT
+    def test_mock_minio_bucket_init(self):
+        mock_minio_bucket = MockMinioBucket(
+            bucket_name="test-bucket", versioning=VersioningConfig()
+        )
+        assert mock_minio_bucket.bucket_name == "test-bucket"
+        assert mock_minio_bucket.versioning.status == OFF
+        assert mock_minio_bucket.objects == {}
+
+        versioning_config = VersioningConfig(ENABLED)
+        mock_minio_bucket = MockMinioBucket(
+            bucket_name="test-bucket", versioning=versioning_config
+        )
+        assert isinstance(mock_minio_bucket._versioning, VersioningConfig)
+        assert mock_minio_bucket.versioning.status == ENABLED
+
+    @pytest.mark.UNIT
+    def test_versioning(self):
+        mock_minio_bucket = MockMinioBucket(
+            bucket_name="test-bucket", versioning=VersioningConfig()
+        )
+        versioning_config = mock_minio_bucket.versioning
+        assert isinstance(versioning_config, VersioningConfig)
+        assert versioning_config.status == OFF
+        versioning_config = VersioningConfig(status=ENABLED)
+        mock_minio_bucket.versioning = versioning_config
+        versioning_config = mock_minio_bucket.versioning
+        assert isinstance(versioning_config, VersioningConfig)
+        assert versioning_config.status == ENABLED

--- a/tests/test_minio_mock_client.py
+++ b/tests/test_minio_mock_client.py
@@ -19,6 +19,7 @@ class TestsMockMinioClient:
         assert client._region == None
         assert client._http_client == None
         assert client._credentials == None
+        assert client._cert_check is True
 
     @pytest.mark.UNIT
     def test_mock_minio_client_init_with_all_params(self):
@@ -30,6 +31,7 @@ class TestsMockMinioClient:
         region = "us-east-1"
         http_client = "mock_http_client"
         credentials = "mock_credentials"
+        cert_check = False
 
         client = MockMinioClient(
             endpoint,
@@ -40,6 +42,7 @@ class TestsMockMinioClient:
             region=region,
             http_client=http_client,
             credentials=credentials,
+            cert_check=cert_check,
         )
 
         assert client._base_url == endpoint, "Endpoint should be stored correctly"
@@ -56,6 +59,7 @@ class TestsMockMinioClient:
         assert (
             client._credentials == credentials
         ), "Credentials should be stored correctly"
+        assert client._cert_check == cert_check
 
     @pytest.mark.UNIT
     def test_mock_minio_client_init_error_handling(self):

--- a/tests/test_minio_mock_client.py
+++ b/tests/test_minio_mock_client.py
@@ -1,0 +1,65 @@
+"""
+"""
+import pytest
+
+from pytest_minio_mock.plugin import MockMinioClient
+
+
+@pytest.mark.UNIT
+class TestsMockMinioClient:
+    @pytest.mark.UNIT
+    def test_mock_minio_client_init_with_minimal_parameters(self):
+        endpoint = "http://localhost:9000"
+        client = MockMinioClient(endpoint)
+        assert client._base_url == endpoint
+        assert client._access_key == None
+        assert client._secret_key == None
+        assert client._session_token == None
+        assert client._secure is True
+        assert client._region == None
+        assert client._http_client == None
+        assert client._credentials == None
+
+    @pytest.mark.UNIT
+    def test_mock_minio_client_init_with_all_params(self):
+        endpoint = "http://localhost:9000"
+        access_key = "accessKey"
+        secret_key = "secretKey"
+        session_token = "sessionToken"
+        secure = False
+        region = "us-east-1"
+        http_client = "mock_http_client"
+        credentials = "mock_credentials"
+
+        client = MockMinioClient(
+            endpoint,
+            access_key=access_key,
+            secret_key=secret_key,
+            session_token=session_token,
+            secure=secure,
+            region=region,
+            http_client=http_client,
+            credentials=credentials,
+        )
+
+        assert client._base_url == endpoint, "Endpoint should be stored correctly"
+        assert client._access_key == access_key, "Access key should be stored correctly"
+        assert client._secret_key == secret_key, "Secret key should be stored correctly"
+        assert (
+            client._session_token == session_token
+        ), "Session token should be stored correctly"
+        assert client._secure == secure, "Secure should reflect the passed value"
+        assert client._region == region, "Region should be stored correctly"
+        assert (
+            client._http_client == http_client
+        ), "HTTP client should be stored correctly"
+        assert (
+            client._credentials == credentials
+        ), "Credentials should be stored correctly"
+
+    @pytest.mark.UNIT
+    def test_mock_minio_client_init_error_handling(self):
+        with pytest.raises(
+            TypeError, match="missing 1 required positional argument: 'endpoint'"
+        ):
+            client = MockMinioClient()  # not passing endpoint should raise an error

--- a/tests/test_minio_mock_objects.py
+++ b/tests/test_minio_mock_objects.py
@@ -1,0 +1,13 @@
+"""
+"""
+import pytest
+
+from pytest_minio_mock.plugin import MockMinioObject
+
+
+@pytest.mark.UNIT
+class TestsMockMinioObject:
+    @pytest.mark.UNIT
+    def test_mock_minio_object_init(self):
+        mock_minio_object = MockMinioObject("test-bucket", "test-object")
+        assert mock_minio_object.versions == {}


### PR DESCRIPTION
### Bug Fixes
- added a missing parameter `cert_check` to the MockMinioClient.__init__() interface of MockMinioClient, that is present in `minio.Minio.__init__()` but was missing from the mocked class.

### For Developers
- Reorganised the tests in smaller test files. Now every class has a dedicated test file mostly for unit testing such as `tests/test_minio_mock_bucket.py`
- and functional tests are in `tests/test_minio_mock.py`
- added tests for the MockMinioClient.__init__() interface to ensure replication of minio.Minio.__init__(). The same technique will be used to ensure the interface of all functions in the future.
- Test is now > 92%

### Credits
Thanks to @gatagat for raising the issue and creating the pull request.