### PR TITLE
handle custom __new__ arguments in Minio mock fixture and few adjustments

### DIFF
--- a/pytest_minio_mock/plugin.py
+++ b/pytest_minio_mock/plugin.py
@@ -1453,5 +1453,9 @@ def minio_mock(mocker, minio_mock_servers):
         client.connect(minio_mock_servers)
         return client
 
-    patched = mocker.patch.object(Minio, "__new__", new=minio_mock_init)
-    yield patched
+    patched = mocker.patch.object(Minio, "__new__", new=minio_mock_init, create=True)
+    try:
+        yield patched
+        mocker.stop(patched)
+    finally:
+        Minio.__new__ = lambda cls, *args, **kw: object.__new__(cls)

--- a/pytest_minio_mock/plugin.py
+++ b/pytest_minio_mock/plugin.py
@@ -267,7 +267,7 @@ class MockMinioObject:
                 object_name=self.object_name,
             )
 
-        # If version == None, give version_id a value
+        # If version is None, give version_id a value
         if not version_id:
             if not self._versions:
                 raise S3Error(
@@ -547,7 +547,7 @@ class MockMinioBucket:
 
         try:
             the_object = self.objects[object_name]
-        except KeyError as e:
+        except KeyError:
             raise S3Error(
                 message="Object does not exist",
                 resource=f"/{self.bucket_name}/{object_name}",
@@ -1436,30 +1436,24 @@ def minio_mock_servers():
 
 
 @pytest.fixture
-def minio_mock(mocker, minio_mock_servers):
+def minio_mock(minio_mock_servers):
     """
     Pytest fixture to patch the Minio client with a mock.
 
     Args:
-        mocker: The pytest-mock fixture.
         minio_mock_servers: The fixture providing a Servers instance.
 
     Yields:
         MockMinioClient: The patched Minio client.
     """
 
-    def minio_mock_init(
-        cls,
-        *args,
-        **kwargs,
-    ):
+    def minio_mock_init(cls, *args, **kwargs):
         client = MockMinioClient(*args, **kwargs)
         client.connect(minio_mock_servers)
         return client
 
-    patched = mocker.patch.object(Minio, "__new__", new=minio_mock_init, create=True)
+    Minio.__new__ = minio_mock_init
     try:
-        yield patched
-        mocker.stop(patched)
+        yield Minio
     finally:
         Minio.__new__ = lambda cls, *args, **kw: object.__new__(cls)

--- a/pytest_minio_mock/plugin.py
+++ b/pytest_minio_mock/plugin.py
@@ -820,7 +820,7 @@ class MockMinioClient:
         if not self._base_url:
             raise ValueError("base_url is empty")
         if not validators.hostname(self._base_url) and not validators.url(
-            self._base_url
+            self._base_url, simple_host=True
         ):
             raise ValueError(f"base_url {self._base_url} is not valid")
 

--- a/tests/test_minio_mock_client.py
+++ b/tests/test_minio_mock_client.py
@@ -86,3 +86,17 @@ class TestsMockMinioClient:
             TypeError, match="missing 1 required positional argument: 'endpoint'"
         ):
             client = MockMinioClient()  # not passing endpoint should raise an error
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "http://localhost:9000",
+            "https://localhost:9000",
+            "localhost:9000",
+            "any-endpoint.local",
+        ],
+    )
+    @pytest.mark.UNIT
+    def test_mock_minio_client_health_check(self, endpoint: str):
+        client = MockMinioClient(endpoint)
+        assert client._health_check() is None

--- a/tests/test_minio_mock_client.py
+++ b/tests/test_minio_mock_client.py
@@ -17,13 +17,13 @@ class TestsMockMinioClient:
 
         base_url_schema = "https" if is_secure else "http"
         assert client._base_url == f"{base_url_schema}://{endpoint}"
-        assert client._access_key == None
-        assert client._secret_key == None
-        assert client._session_token == None
+        assert client._access_key is None
+        assert client._secret_key is None
+        assert client._session_token is None
         assert client._secure is is_secure
-        assert client._region == None
-        assert client._http_client == None
-        assert client._credentials == None
+        assert client._region is None
+        assert client._http_client is None
+        assert client._credentials is None
         assert client._cert_check is True
 
     @pytest.mark.UNIT
@@ -31,13 +31,13 @@ class TestsMockMinioClient:
         endpoint = "https://localhost:9000"
         client = MockMinioClient(endpoint)
         assert client._base_url == endpoint
-        assert client._access_key == None
-        assert client._secret_key == None
-        assert client._session_token == None
+        assert client._access_key is None
+        assert client._secret_key is None
+        assert client._session_token is None
         assert client._secure is True
-        assert client._region == None
-        assert client._http_client == None
-        assert client._credentials == None
+        assert client._region is None
+        assert client._http_client is None
+        assert client._credentials is None
         assert client._cert_check is True
 
     @pytest.mark.UNIT
@@ -85,7 +85,7 @@ class TestsMockMinioClient:
         with pytest.raises(
             TypeError, match="missing 1 required positional argument: 'endpoint'"
         ):
-            client = MockMinioClient()  # not passing endpoint should raise an error
+            MockMinioClient()  # not passing endpoint should raise an error
 
     @pytest.mark.parametrize(
         "endpoint",

--- a/tests/test_minio_mock_client.py
+++ b/tests/test_minio_mock_client.py
@@ -7,11 +7,30 @@ from pytest_minio_mock.plugin import MockMinioClient
 
 @pytest.mark.UNIT
 class TestsMockMinioClient:
+    @pytest.mark.parametrize("is_secure", [True, False])
+    @pytest.mark.UNIT
+    def test_mock_minio_client_init_without_endpoint_schema_and_with_minimal_parameters(
+        self, is_secure: bool
+    ):
+        endpoint = "localhost:9000"
+        client = MockMinioClient(endpoint, secure=is_secure)
+
+        base_url_schema = "https" if is_secure else "http"
+        assert client._base_url == f"{base_url_schema}://{endpoint}"
+        assert client._access_key == None
+        assert client._secret_key == None
+        assert client._session_token == None
+        assert client._secure is is_secure
+        assert client._region == None
+        assert client._http_client == None
+        assert client._credentials == None
+        assert client._cert_check is True
+
     @pytest.mark.UNIT
     def test_mock_minio_client_init_with_minimal_parameters(self):
         endpoint = "https://localhost:9000"
         client = MockMinioClient(endpoint)
-        assert client._base_url.url == endpoint
+        assert client._base_url == endpoint
         assert client._access_key == None
         assert client._secret_key == None
         assert client._session_token == None
@@ -45,7 +64,7 @@ class TestsMockMinioClient:
             cert_check=cert_check,
         )
 
-        assert client._base_url.url == endpoint, "Endpoint should be stored correctly"
+        assert client._base_url == endpoint, "Endpoint should be stored correctly"
         assert client._access_key == access_key, "Access key should be stored correctly"
         assert client._secret_key == secret_key, "Secret key should be stored correctly"
         assert (

--- a/tests/test_minio_mock_client.py
+++ b/tests/test_minio_mock_client.py
@@ -9,9 +9,9 @@ from pytest_minio_mock.plugin import MockMinioClient
 class TestsMockMinioClient:
     @pytest.mark.UNIT
     def test_mock_minio_client_init_with_minimal_parameters(self):
-        endpoint = "http://localhost:9000"
+        endpoint = "https://localhost:9000"
         client = MockMinioClient(endpoint)
-        assert client._base_url == endpoint
+        assert client._base_url.url == endpoint
         assert client._access_key == None
         assert client._secret_key == None
         assert client._session_token == None
@@ -45,7 +45,7 @@ class TestsMockMinioClient:
             cert_check=cert_check,
         )
 
-        assert client._base_url == endpoint, "Endpoint should be stored correctly"
+        assert client._base_url.url == endpoint, "Endpoint should be stored correctly"
         assert client._access_key == access_key, "Access key should be stored correctly"
         assert client._secret_key == secret_key, "Secret key should be stored correctly"
         assert (


### PR DESCRIPTION
Change Summary
- [x] Resolved an issue where extra arguments passed to a custom __new__ method caused instantiation errors.
- [x] Updated the minio_mock fixture to ensure __new__ is properly patched and restored.
- [x] Introduced a permanent stub for Minio.__new__ to handle instantiation arguments correctly when restoring the patch.
- [x] Updated _base_url to parse and normalize the endpoint URL, ensuring consistent handling of secure and non-secure connections.

Related issue number
 - fixes #5 (for real now)

Checklist
 - [x] code is ready
 - [x] add tests
 - [x] all tests passing
 - [x] test coverage did not drop
 - [x] PR is ready for review


Thanks @bernd-k1337 for solution!