### PR TITLE
fix fput_object

### DIFF
--- a/pytest_minio_mock/plugin.py
+++ b/pytest_minio_mock/plugin.py
@@ -1002,7 +1002,7 @@ class MockMinioClient:
             return self.put_object(
                 bucket_name,
                 object_name,
-                file_data,
+                file_data.read(),
                 length=file_size,
                 content_type="application/octet-stream",
                 metadata=metadata,


### PR DESCRIPTION
Change Summary
 - Fixed empty files being added when using `fput_object` added `.read()`
Checklist
  [x] code is ready
  [x] add tests
  [x] all tests passing
  [x] test coverage did not drop
  [x] PR is ready for review